### PR TITLE
Add DiskCache, change cache creation

### DIFF
--- a/src/main/java/com/buuz135/thaumicjei/AspectFromItemStacksHelper.java
+++ b/src/main/java/com/buuz135/thaumicjei/AspectFromItemStacksHelper.java
@@ -1,0 +1,109 @@
+package com.buuz135.thaumicjei;
+
+import com.buuz135.thaumicjei.AspectFromItemStacksHelper;
+import com.buuz135.thaumicjei.category.*;
+import com.buuz135.thaumicjei.config.ThaumicConfig;
+import com.buuz135.thaumicjei.ingredient.AspectIngredientFactory;
+import com.buuz135.thaumicjei.ingredient.AspectIngredientHelper;
+import com.buuz135.thaumicjei.ingredient.AspectIngredientRender;
+import com.buuz135.thaumicjei.StackSizeComparator;
+import com.google.common.collect.ArrayListMultimap;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import mezz.jei.api.*;
+import mezz.jei.api.ingredients.IModIngredientRegistration;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.CrucibleRecipe;
+import thaumcraft.api.crafting.IArcaneRecipe;
+import thaumcraft.api.crafting.InfusionRecipe;
+import thaumcraft.api.internal.CommonInternals;
+import thaumcraft.api.ThaumcraftApi;
+import thaumcraft.client.gui.GuiArcaneWorkbench;
+import thaumcraft.common.container.ContainerArcaneWorkbench;
+import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
+
+class AspectFromItemStacksHelper{
+    public static long TCCalculation(IModRegistry registry){
+        long time = System.currentTimeMillis();
+        ThaumicJEI.LOGGER.info("Thaumcraft calculating aspects from ItemStacks in the IngredientRegistry");
+        for (ItemStack stack : registry.getIngredientRegistry().getIngredients(ItemStack.class).asList()) {
+            thaumcraft.common.lib.crafting.ThaumcraftCraftingManager.generateTags(stack);
+        }
+        ThaumicJEI.LOGGER.info("Thaumcraft calculated aspects in " + (System.currentTimeMillis() - time) + "ms");
+        return (System.currentTimeMillis() - time);
+    }
+    
+    
+    public static ArrayListMultimap<Aspect, ItemStack> GenerateAspectCache(){
+        ArrayListMultimap<Aspect, ItemStack> aspectCache = ArrayListMultimap.create();
+        long time = System.currentTimeMillis();
+        int isCounter = 0;
+        ThaumicJEI.LOGGER.info("Adding " + CommonInternals.objectTags.mappingCount() + " potential items to the aspect cache");
+        try{
+            //reflection to prevent one unneccsary .serializeNBT().toString() call
+            Method cA = ThaumcraftCraftingManager.class.getDeclaredMethod("capAspects",new Class[]{AspectList.class,int.class});
+            cA.setAccessible(true);
+            Method gBT = ThaumcraftCraftingManager.class.getDeclaredMethod("getBonusTags",new Class[]{ItemStack.class,AspectList.class});
+            gBT.setAccessible(true);
+            for(String s : CommonInternals.objectTags.keySet()){
+                try{
+                    ItemStack stack = ItemStack.loadItemStackFromNBT((NBTTagCompound)JsonToNBT.getTagFromJson(s));
+                    isCounter++;
+                    AspectList list = CommonInternals.objectTags.get(s); 
+                    list = (AspectList)cA.invoke(null, new Object[] {gBT.invoke(null, new Object[] {stack, list}), 500});
+                    if (list.size() > 0) {
+                        for (Aspect aspect : list.getAspects()) {
+                            ItemStack clone = stack.copy();
+                            clone.stackSize = list.getAmount(aspect);
+                            aspectCache.put(aspect, clone);
+                        }
+                    }
+                }catch(Exception e){
+                    isCounter--;
+                }
+            }
+        } catch (Exception e){
+            e.printStackTrace();
+        }
+        ThaumicJEI.LOGGER.info("Cached " + isCounter + " real ItemStack aspects in " + (System.currentTimeMillis() - time) + "ms");
+        return aspectCache;
+    }
+    
+    
+    public static List<AspectFromItemStackCategory.AspectFromItemStackWrapper> GenerateWrappers(ArrayListMultimap<Aspect,ItemStack> aspectCache){
+        long time = System.currentTimeMillis();
+        List<AspectFromItemStackCategory.AspectFromItemStackWrapper> wrappers = new ArrayList<>();
+        for (Aspect aspect : aspectCache.keySet()) {
+            List<ItemStack> itemStacks = aspectCache.get(aspect);
+            Collections.sort(itemStacks, new StackSizeComparator());
+            int start = 0;
+            while (start < itemStacks.size()) {
+                wrappers.add(new AspectFromItemStackCategory.AspectFromItemStackWrapper(aspect, itemStacks.subList(start, Math.min(start + 36, itemStacks.size()))));
+                start += 36;
+            }
+        }
+        ThaumicJEI.LOGGER.info("Created recipes " + (System.currentTimeMillis() - time) + "ms");
+        return wrappers;
+    }
+    
+    
+    public static void waitTill15000(long duration){
+        if (15000>duration){
+            ThaumicJEI.LOGGER.info("That took less than 15s, waiting " + (15000-duration) + "ms");
+            try {
+               Thread.sleep(15000-duration);
+            }catch(InterruptedException e){}
+        }
+    }
+}

--- a/src/main/java/com/buuz135/thaumicjei/AspectListAdapter.java
+++ b/src/main/java/com/buuz135/thaumicjei/AspectListAdapter.java
@@ -1,0 +1,41 @@
+package com.buuz135.thaumicjei;
+
+import com.google.gson.stream.*;
+import com.google.gson.*;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.aspects.Aspect;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTTagCompound;
+import java.io.IOException;
+   
+   
+public class AspectListAdapter extends TypeAdapter<AspectList> {
+    public AspectList read(JsonReader reader) throws IOException {
+        AspectList list = new AspectList();
+        reader.beginObject();
+        reader.nextName();
+        reader.beginArray();
+        while(reader.hasNext()){
+            reader.beginObject();
+            list.add(Aspect.getAspect(reader.nextName()), reader.nextInt());
+            reader.endObject();
+        }
+        reader.endArray();
+        reader.endObject();
+        return list;
+    }
+    
+    public void write(JsonWriter writer, AspectList list) throws IOException {
+        writer.beginObject();
+        writer.name("Aspects");
+        writer.beginArray();
+        for(Aspect a : list.getAspects()){
+            writer.beginObject();
+            writer.name(a.getTag());
+            writer.value(list.getAmount(a));
+            writer.endObject();
+        }
+        writer.endArray();
+        writer.endObject();
+    }
+}

--- a/src/main/java/com/buuz135/thaumicjei/DiskCacheHandler.java
+++ b/src/main/java/com/buuz135/thaumicjei/DiskCacheHandler.java
@@ -1,0 +1,147 @@
+package com.buuz135.thaumicjei;
+
+
+import com.buuz135.thaumicjei.AspectListAdapter;
+import com.buuz135.thaumicjei.TCAspectCacheUtils;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.File;
+import java.lang.reflect.Type;
+import java.text.Collator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.TreeSet;
+import java.util.Collections;
+import java.util.ArrayList;
+
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTTagCompound;
+
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.internal.CommonInternals;
+
+
+class DiskCacheHandler{
+    public static Gson gson;
+    private static File modFile = new File("./config/ThaumicJEI/mods.txt");
+    private static File startObjectTagFile = new File("./config/ThaumicJEI/startObjectTags.txt");
+    private static File cacheFile = new File("./config/ThaumicJEI/cache.txt");
+
+    public static void save(ConcurrentHashMap<String,AspectList> startObjectTags){
+        gson = new GsonBuilder()
+            .registerTypeAdapter(AspectList.class, new AspectListAdapter())
+            .enableComplexMapKeySerialization()
+            .serializeNulls()
+            .setPrettyPrinting()
+            .setVersion(1.0)
+            .create();
+        try{
+            new File("./config/ThaumicJEI").mkdir();
+        }catch(Exception e){
+            e.printStackTrace();
+        }
+        try{
+            FileWriter fw = new FileWriter(cacheFile);
+            fw.write(gson.toJson(CommonInternals.objectTags));
+            
+            fw.close();
+            
+            fw = new FileWriter(modFile);
+            ArrayList modlist = new ArrayList();
+            for (ModContainer modContainer : Loader.instance().getActiveModList()) {
+                String mod = modContainer.getModId() + "#" + modContainer.getVersion();
+                modlist.add(mod);
+                Collections.sort(modlist, Collator.getInstance());
+            }
+            fw.write(gson.toJson(modlist));
+            fw.close();
+            
+            fw = new FileWriter(startObjectTagFile);
+            fw.write(gson.toJson(startObjectTags));
+            //fw.flush();
+            fw.close();
+            /*
+            FileReader fr = new FileReader("./startObjectTags.txt");
+            Type type = new TypeToken<ConcurrentHashMap<String,AspectList>>(){}.getType();
+            if(TCAspectCacheUtils.areEqual(startObjectTags, gson.fromJson(fr, type))){
+                ThaumicJEI.LOGGER.info("startObjectTags equal after creation");
+            }
+            fr.close();*/
+        }catch(Exception e){
+            e.printStackTrace();
+        }
+    }
+    
+    public static boolean equal(ConcurrentHashMap<String,AspectList> startObjectTags){
+        gson = new GsonBuilder()
+            .registerTypeAdapter(AspectList.class, new AspectListAdapter())
+            .enableComplexMapKeySerialization()
+            .serializeNulls()
+            .setPrettyPrinting()
+            .setVersion(1.0)
+            .create();
+        if(!modFile.isFile()||!startObjectTagFile.isFile()||!cacheFile.isFile()){
+            return false;
+        }
+        try{            
+            FileReader fr = new FileReader(modFile);
+            ArrayList modlist = new ArrayList();
+            for (ModContainer modContainer : Loader.instance().getActiveModList()) {
+                String mod = modContainer.getModId() + "#" + modContainer.getVersion();
+                modlist.add(mod);
+                Collections.sort(modlist, Collator.getInstance());
+            }
+            Type type = new TypeToken<ArrayList<String>>(){}.getType();
+            ArrayList<String> modlistNew = gson.fromJson(fr, type);
+            Collections.sort(modlistNew, Collator.getInstance());
+            if(!modlist.containsAll(modlistNew) || !modlistNew.containsAll(modlist)){
+                ThaumicJEI.LOGGER.info(gson.toJson(modlist));
+                ThaumicJEI.LOGGER.info(gson.toJson(modlistNew));
+                ThaumicJEI.LOGGER.info("mods not equal");
+                fr.close();
+                return false;
+            }
+            fr.close();
+            
+            fr = new FileReader(startObjectTagFile);
+            type = new TypeToken<ConcurrentHashMap<String,AspectList>>(){}.getType();
+            if(!TCAspectCacheUtils.areEqual(startObjectTags, gson.fromJson(fr, type))){
+                ThaumicJEI.LOGGER.info("startObjectTags not equal");
+                fr.close();
+                return false;
+            }
+            fr.close();
+            return true;
+        }catch(Exception e){
+            e.printStackTrace();
+        }
+        return false;
+    }
+    
+    
+    public static void load(){
+        gson = new GsonBuilder()
+            .registerTypeAdapter(AspectList.class, new AspectListAdapter())
+            .enableComplexMapKeySerialization()
+            .serializeNulls()
+            .setPrettyPrinting()
+            .setVersion(1.0)
+            .create();
+        try{ 
+            
+            FileReader fr = new FileReader(cacheFile);
+            Type type = new TypeToken<ConcurrentHashMap<String,AspectList>>(){}.getType();
+            CommonInternals.objectTags = gson.fromJson(fr, type);
+            fr.close();
+        }catch(Exception e){
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/buuz135/thaumicjei/StackSizeComparator.java
+++ b/src/main/java/com/buuz135/thaumicjei/StackSizeComparator.java
@@ -1,0 +1,32 @@
+package com.buuz135.thaumicjei;
+
+import java.util.*;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Item;
+
+class StackSizeComparator implements Comparator{  
+    public int compare(Object o1,Object o2){  
+        ItemStack s1=(ItemStack)o1;  
+        ItemStack s2=(ItemStack)o2;  
+  
+        if(s1.stackSize==s2.stackSize) {
+            if (Item.getIdFromItem(s1.getItem())==Item.getIdFromItem(s2.getItem())){
+                if (s1.getItemDamage()==s2.getItemDamage()){
+                    return 0;
+                } else if(s1.getItemDamage()<s2.getItemDamage()) {
+                    return -1;  
+                } else {
+                    return 1; 
+                }                  
+            } else if(Item.getIdFromItem(s1.getItem())<Item.getIdFromItem(s2.getItem())) {
+                return -1;  
+            } else {
+                return 1; 
+            }  
+        } else if(s1.stackSize>s2.stackSize) {
+            return -1;  
+        } else {
+            return 1; 
+        } 
+    }  
+}  

--- a/src/main/java/com/buuz135/thaumicjei/TCAspectCacheUtils.java
+++ b/src/main/java/com/buuz135/thaumicjei/TCAspectCacheUtils.java
@@ -1,0 +1,51 @@
+package com.buuz135.thaumicjei;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.internal.CommonInternals;
+
+class TCAspectCacheUtils{
+    public static ConcurrentHashMap<String,AspectList> createDeepCopy(ConcurrentHashMap<String,AspectList> TCAspectCache){
+        ConcurrentHashMap<String,AspectList> copy = new ConcurrentHashMap<String,AspectList>();
+    
+        for(String item : TCAspectCache.keySet()){
+            AspectList aspectListCopy = new AspectList();
+            aspectListCopy.add(TCAspectCache.get(item));
+            copy.put(item, aspectListCopy);
+        }
+        return copy;
+    }
+    public static boolean areEqual(ConcurrentHashMap<String,AspectList> mapA,ConcurrentHashMap<String,AspectList> mapB){
+        AspectList aspectListA;
+        AspectList aspectListB;
+        if (mapA.size()!=mapB.size()){
+            ThaumicJEI.LOGGER.info("One of the TCAspectCaches has a different size than the other one");
+            return false;
+        }
+        if (mapA.isEmpty()){
+            return true;
+        }
+        for(String item : mapA.keySet()){
+            aspectListA = mapA.get(item);
+            aspectListB = mapB.get(item);
+            if(aspectListB==null){
+                ThaumicJEI.LOGGER.info("Item: " + item + "is not registered in mapB");
+                return false;
+            }
+            if(aspectListA.aspects.size()!=aspectListA.aspects.size()) {
+                ThaumicJEI.LOGGER.info("Item: " + item + "the AspectLists differs in size");
+            }
+            for (Aspect aspect : aspectListA.aspects.keySet()){
+                if((int)aspectListA.aspects.get(aspect)!=(int)aspectListB.aspects.get(aspect)){
+                    ThaumicJEI.LOGGER.info("Item: " + item + "has Aspect:" + aspect.getTag());
+                    ThaumicJEI.LOGGER.info("In aspectListA = " + aspectListA.aspects.get(aspect));
+                    ThaumicJEI.LOGGER.info("In aspectListB = " + aspectListB.aspects.get(aspect));
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/buuz135/thaumicjei/config/ThaumicConfig.java
+++ b/src/main/java/com/buuz135/thaumicjei/config/ThaumicConfig.java
@@ -1,3 +1,4 @@
+
 package com.buuz135.thaumicjei.config;
 
 import com.buuz135.thaumicjei.ThaumicJEI;
@@ -6,6 +7,8 @@ import net.minecraftforge.common.config.Config;
 @Config(modid = ThaumicJEI.MOD_ID)
 public class ThaumicConfig {
 
-    @Config.Comment("Allow the scanning of all items in game to show what items can make aspects. WARNING: This can be performance heavy but it won't add load time to the pack, everything is done in a new thread and it might take a while to appear in game!")
+    @Config.Comment("Allow the scanning of all items in game to show what items can make aspects. This can be performance heavy.")
     public static boolean enableAspectFromItemStacks = true;
+    @Config.Comment("Enabling this switch adds load time to the pack by diabling threading for AspectFromItemStacks but makes sure everything is loaded from the beginning and prevents a (theoretically) possible bug. If you leave this switch disabled everything will be done in a new thread and might take a while to appear in game.")
+    public static boolean disableThreading = false;
 }


### PR DESCRIPTION
 - added caching to/from file to speed up susequent starts (Warning: This makes it possible to add 
aspects to ItemStacks and modify what aspects they have as i actually modify Thaumcraft's internal cache. If you do not like that, i can modify it to save and load only Thaumic JEI's Cache) This cache gets regenerated when mods/their versions change (possibly items got added, aspects modified) or when the initial Cache at the time Thaumic JEI checks is changes (this should catch if an mod adds an option to change aspects, or alowes modifying them via some config file).
 - added sorting to Aspect from ItemStacks. (first by amount, than by id, then by damage)
 - added proper handeling of visCrystals, phials and labels by JEI. (labels might be a bad idea as they probably reduce JEI performance and are not used in recipes).
 - added option to disable threading.
 - fixed #8 while destroying performance on first start in big packs. (did **not** test if your code fixed is faster)
 - Refactored Aspect from ItemStacks moving logic in other classes (names might be bad, my first java coding experience, i do not know how to name them better)
 - probably added/did not remove lots of unnecessary includes. (i have no idea how to check that time effective)