### PR TITLE
Fix aspect count being capped at 127

### DIFF
--- a/src/main/java/com/buuz135/thaumicjei/ThaumcraftJEIPlugin.java
+++ b/src/main/java/com/buuz135/thaumicjei/ThaumcraftJEIPlugin.java
@@ -42,6 +42,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.nbt.JsonToNBT;
 import net.minecraft.nbt.NBTException;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
@@ -144,7 +145,11 @@ public class ThaumcraftJEIPlugin implements IModPlugin {
                                 e.printStackTrace();
                             }
                             return null;
-                        }).filter(Objects::nonNull).map(compound -> new ItemStack(compound)).filter(stack -> !stack.isEmpty()).sorted(Comparator.comparing(ItemStack::getCount).reversed()).collect(Collectors.toList());
+                        }).filter(Objects::nonNull).map(compound -> {
+                            ItemStack itemStack = new ItemStack(compound);
+                            itemStack.setCount(compound.getShort("Count"));
+                            return itemStack;
+                        }).filter(stack -> !stack.isEmpty()).sorted(Comparator.comparing(ItemStack::getCount).reversed()).collect(Collectors.toList());
                         int start = 0;
                         while (start < items.size()) {
                             wrappers.add(new AspectFromItemStackCategory.AspectFromItemStackWrapper(new AspectList().add(aspect, 1), items.subList(start, Math.min(start + 36, items.size()))));
@@ -204,7 +209,9 @@ public class ThaumcraftJEIPlugin implements IModPlugin {
                     ItemStack clone = stack.copy();
                     clone.setCount(list.getAmount(aspect));
                     AspectCache cache = aspectCacheHashMap.getOrDefault(aspect, new AspectCache(aspect.getTag()));
-                    cache.items.add(clone.serializeNBT().toString());
+                    NBTTagCompound nbtTagCompound = clone.serializeNBT();
+                    nbtTagCompound.setShort("Count", (short) clone.getCount());
+                    cache.items.add(nbtTagCompound.toString());
                     aspectCacheHashMap.put(aspect, cache);
                 }
             }


### PR DESCRIPTION
Due to how ItemStack reads/writes the count to NBT (byte value),
Some ItemStacks with > 127 of an aspect will get handled wrongly.

If the byte representing the count in NBT was negative,
then ThaumicJEI didn't display those at all, due to ItemStack#isEmpty() being true.
If the byte count was > 0, then it was just a wrong number.

This Commit/PR allows for up to Short.MAX_VALUE (32 767) aspects to be still representable,
by manually overriding the NBT compound to use item count as short type.
I think that this number should be high enough for any (modded) item,
but it could be bumped up to use integer count instead, just to be sure.

This change will only work for newly generated aspect json files.
Old, pre-existing ones will still behave the way they did previously.

[Screenshot](https://i.imgur.com/v4zXXKL.png)

Fixes #14 