### PR TITLE
Fix crash during register with EnderIO 5.0.43

### DIFF
--- a/src/main/java/com/buuz135/thaumicjei/ThaumcraftJEIPlugin.java
+++ b/src/main/java/com/buuz135/thaumicjei/ThaumcraftJEIPlugin.java
@@ -146,8 +146,11 @@ public class ThaumcraftJEIPlugin implements IModPlugin {
                             }
                             return null;
                         }).filter(Objects::nonNull).map(compound -> {
+                            short trueCount = compound.getShort("Count");
+                            if (trueCount > Byte.MAX_VALUE)
+                                compound.setByte("Count", Byte.MAX_VALUE);
                             ItemStack itemStack = new ItemStack(compound);
-                            itemStack.setCount(compound.getShort("Count"));
+                            itemStack.setCount(trueCount);
                             return itemStack;
                         }).filter(stack -> !stack.isEmpty()).sorted(Comparator.comparing(ItemStack::getCount).reversed()).collect(Collectors.toList());
                         int start = 0;


### PR DESCRIPTION
As described by PR #39, aspect counts > 127 result in a negative or incorrect value during construction. In the case of a negative, EnderIO is throwing an exception from one of its item init callbacks due to getting AIR when calling getItem instead of the actual item.

This is a simple fix to ensure the ItemStack count is always positive during construction. 

```
java.lang.ClassCastException: net.minecraft.item.ItemAir cannot be cast to crazypants.enderio.base.power.forge.item.IInternalPoweredItem
	at crazypants.enderio.base.power.forge.item.InternalPoweredItemCap.<init>(InternalPoweredItemCap.java:15) ~[InternalPoweredItemCap.class:?]
	at crazypants.enderio.powertools.machine.capbank.BlockItemCapBank.initCapabilities(BlockItemCapBank.java:22) ~[BlockItemCapBank.class:?]
	at net.minecraft.item.ItemStack.forgeInit(ItemStack.java:1216) ~[aip.class:?]
	at net.minecraft.item.ItemStack.<init>(ItemStack.java:138) ~[aip.class:?]
	at com.buuz135.thaumicjei.ThaumcraftJEIPlugin.lambda$register$4(ThaumcraftJEIPlugin.java:149) ~[ThaumcraftJEIPlugin.class:?]
        ...
	at com.buuz135.thaumicjei.ThaumcraftJEIPlugin.register(ThaumcraftJEIPlugin.java:152) ~[ThaumcraftJEIPlugin.class:?]
	at mezz.jei.startup.JeiStarter.registerPlugins(JeiStarter.java:202) [JeiStarter.class:?]
	at mezz.jei.startup.JeiStarter.start(JeiStarter.java:73) [JeiStarter.class:?]
        ...
```