### PR TITLE
Log and ignore JSON syntax errors in aspect cache file

### DIFF
--- a/src/main/java/com/buuz135/thaumicjei/ThaumcraftJEIPlugin.java
+++ b/src/main/java/com/buuz135/thaumicjei/ThaumcraftJEIPlugin.java
@@ -30,6 +30,7 @@ import com.buuz135.thaumicjei.ingredient.AspectIngredientRender;
 import com.buuz135.thaumicjei.ingredient.AspectListIngredientHelper;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.GsonBuilder;
 import mezz.jei.api.*;
 import mezz.jei.api.ingredients.IModIngredientRegistration;
@@ -163,6 +164,8 @@ public class ThaumcraftJEIPlugin implements IModPlugin {
                     registry.addRecipes(wrappers, aspectFromItemStackCategory.getUid());
                     ThaumicJEI.LOGGER.info("Parsed aspect file in " + (System.currentTimeMillis() - time) + "ms");
                 } catch (FileNotFoundException e) {
+                    e.printStackTrace();
+                } catch (JsonSyntaxException e) {
                     e.printStackTrace();
                 }
             }


### PR DESCRIPTION
Noticed there were no TJEI tabs showing in the JEI window. Checked the startup log and found this:

```
[16:20:52] [Client thread/ERROR] [jei]: Failed to register mod plugin: class com.buuz135.thaumicjei.ThaumcraftJEIPlugin
com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Unterminated array at line 5153 column 6 path $[5].items[33]
	at com.google.gson.Gson.fromJson(Gson.java:902) ~[Gson.class:?]
	at com.google.gson.Gson.fromJson(Gson.java:825) ~[Gson.class:?]
	at com.buuz135.thaumicjei.ThaumcraftJEIPlugin.register(ThaumcraftJEIPlugin.java:137) ~[ThaumcraftJEIPlugin.class:?]
	at mezz.jei.startup.JeiStarter.registerPlugins(JeiStarter.java:202) [JeiStarter.class:?]
	at mezz.jei.startup.JeiStarter.start(JeiStarter.java:73) [JeiStarter.class:?]
	at mezz.jei.startup.ProxyCommonClient.loadComplete(ProxyCommonClient.java:136) [ProxyCommonClient.class:?]
	at mezz.jei.JustEnoughItems.loadComplete(JustEnoughItems.java:55) [JustEnoughItems.class:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_171]
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_171]
```

