### PR TITLE
Update de_de.lang

### DIFF
--- a/src/main/resources/assets/thaumicjei/lang/de_de.lang
+++ b/src/main/resources/assets/thaumicjei/lang/de_de.lang
@@ -1,4 +1,4 @@
 # Thaumic JEI Language File
-thaumicjei.category.aspect_compound.title=Aspekt Zusammensetzung
-thaumicjei.category.aspect_from_itemstack.title=Aspekt vom Gegenstandsstapel
+thaumicjei.category.aspect_compound.title=Aspektzusammensetzung
+thaumicjei.category.aspect_from_itemstack.title=Aspekt des ItemStack
 thaumicjei.category.infusion.title=Arkane Infusion


### PR DESCRIPTION
Fix for #57. It split words that shouldn't be split and translated terms that shouldn't be translated.