### PR TITLE
fix curseforge API download counts and versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Thaumic-JEI [![Curse Forge](http://cf.way2muchnoise.eu/full_thaumic-jei_downloads.svg)](https://minecraft.curseforge.com/projects/thaumic-jei) [![Curse Forge](http://cf.way2muchnoise.eu/versions/thaumic-jei.svg)](https://minecraft.curseforge.com/projects/thaumic-jei) [![GitHub issues](https://img.shields.io/github/issues/Buuz135/thaumic-jei.svg)](https://github.com/Buuz135/thaumic-jei/issues) [![license](https://img.shields.io/github/license/Buuz135/thaumic-jei.svg)]() 
+# Thaumic-JEI [![Curse Forge](http://cf.way2muchnoise.eu/285492.svg)](https://minecraft.curseforge.com/projects/thaumic-jei) [![Curse Forge](http://cf.way2muchnoise.eu/versions/285492.svg)](https://minecraft.curseforge.com/projects/thaumic-jei) [![GitHub issues](https://img.shields.io/github/issues/Buuz135/thaumic-jei.svg)](https://github.com/Buuz135/thaumic-jei/issues) [![license](https://img.shields.io/github/license/Buuz135/thaumic-jei.svg)]() 
 
 A JEI and Thaumcraft addon that displays thaumcraft recipes in JEI.
  


### PR DESCRIPTION
your readme curseforge stats were broken:
![image](https://github.com/user-attachments/assets/e0176bc7-e856-4e35-9576-3d58c5bbeda4)

so I fixed them:
![image](https://github.com/user-attachments/assets/355f5aee-bd9b-482e-a363-56bf3d4e51ec)


